### PR TITLE
Fix bug when only single milestone is present in change log

### DIFF
--- a/changebot/blueprints/changelog_helpers.py
+++ b/changebot/blueprints/changelog_helpers.py
@@ -42,6 +42,10 @@ def find_prs_in_changelog_by_section(content):
             subcontent += line
         previous = line
 
+    if subcontent and version is not None:
+        for pr in find_prs_in_changelog(subcontent):
+            changelog_prs[int(pr)] = version
+
     return changelog_prs
 
 

--- a/changebot/blueprints/tests/test_changelog_helpers.py
+++ b/changebot/blueprints/tests/test_changelog_helpers.py
@@ -1,0 +1,91 @@
+import pytest
+
+from ..changelog_helpers import review_changelog
+
+
+def test_review_good_changelog():
+    content = """
+1.1.0 (unreleased)
+==================
+
+- I made some changes. They were good. [#10]
+
+1.0.0 (11-11-2011)
+==================
+
+- Fixed a bug some other person made. Not my fault. [#2]
+    """
+
+    issues = review_changelog(10, content, 'v1.1.0', [])
+    assert len(issues) == 0
+
+
+def test_review_short_changelog():
+    content = """
+1.0.0 (unreleased)
+==================
+
+- It's a whole new thing here now. [#1]
+    """
+
+    issues = review_changelog(1, content, 'v1.0.0', [])
+    assert len(issues) == 0
+
+
+def test_review_long_changelog():
+    content = """
+1.1.0 (unreleased)
+==================
+
+New Features
+------------
+
+foo.bar.baz
+~~~~~~~~~~~
+
+- I made some changes. They were good. [#10]
+
+foo.frob.blurg
+~~~~~~~~~~~~~~
+
+- Wow I don't know how I ever lived without this package. [#9]
+
+Bug Fixes
+---------
+
+foo.bar.baz
+~~~~~~~~~~~
+
+- Oh man this was a really stupid bug. Glad I fixed it. [#11]
+
+foo.frob.blurg
+~~~~~~~~~~~~~~
+
+- Who was the idiot who broke this? It wasn't me. [#12]
+
+1.0.0 (11-11-2011)
+==================
+
+- My code never has bugs. [#2]
+    """
+
+    issues = review_changelog(12, content, 'v1.1.0', [])
+    assert len(issues) == 0
+
+
+@pytest.mark.parametrize('label', ['no-changelog-entry-needed', 'Affects-dev'])
+def test_review_missing_with_tag(label):
+    content = """
+1.1.0 (unreleased)
+==================
+
+- I made some changes. They were good. [#10]
+
+1.0.0 (11-11-2011)
+==================
+
+- Fixed a bug some other person made. Not my fault. [#2]
+    """
+
+    issues = review_changelog(11, content, 'v1.1.0', [label])
+    assert len(issues) == 0


### PR DESCRIPTION
This should fix the problems that were occurring when running against simple test repositories.