### PR TITLE
Make sure hooks entry points return valid values

### DIFF
--- a/changebot/webapp.py
+++ b/changebot/webapp.py
@@ -29,9 +29,9 @@ app.register_blueprint(stale_pull_requests)
 
 @app.route("/")
 def index():
-    return "Nothing to see here"
+    return '{"message": "Nothing to see here"}'
 
 
 @app.route("/installation_authorized")
 def installation_authorized():
-    return "Installation authorized"
+    return '{"message": "Installation authorized"}'


### PR DESCRIPTION
The github webhook endpoint expects a valid JSON value to be returned.