### PR TITLE
Add support for Drizzlepac repo

### DIFF
--- a/changebot/blueprints/changelog_helpers.py
+++ b/changebot/blueprints/changelog_helpers.py
@@ -51,7 +51,7 @@ def find_prs_in_changelog_by_section(content):
 
 def check_changelog_consistency(repo_handler, pr_handler):
 
-    for filename in ('CHANGES.rst', 'CHANGES', 'CHANGES.md'):
+    for filename in ('CHANGES.rst', 'CHANGES', 'CHANGES.md', 'CHANGELOG.rst'):
         try:
             changelog = repo_handler.get_file_contents(filename)
         except FileNotFoundError:


### PR DESCRIPTION
The Drizzlepac repo relies on a change log file with a different name than those originally recognized by this code.  This revision simply adds an entry so that this bot will recognize the change log.  The name of the change log in the Drizzlepac repo would have been changed, except that it is used to generate public facing web-page content automatically.