### PR TITLE
Update to use pyproject.toml for config, optionally disable milestone check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ os:
 matrix:
 
     include:
-        - env: PYTHON_VERSION=3.6 MAIN_CMD='pytest -rx --cov changebot changebot' CONDA_DEPENDENCIES="pytest pytest-cov coverage requests flask cryptography python-dateutil yaml pyyaml" PIP_DEPENDENCIES="coveralls flask-dance pygithub humanize"
+        - env: PYTHON_VERSION=3.6 MAIN_CMD='pytest -rx --cov changebot changebot' CONDA_DEPENDENCIES="pytest pytest-cov coverage requests flask cryptography python-dateutil toml" PIP_DEPENDENCIES="coveralls flask-dance pygithub humanize"
 
         # Do a PEP8 test with flake8
-        - env: PYTHON_VERSION=3.6 MAIN_CMD='pytest --flake8 changebot' CONDA_DEPENDENCIES="pytest pytest-flake8 requests flask cryptography python-dateutil yaml pyyaml" PIP_DEPENDENCIES="flask-dance pygithub humanize"
+        - env: PYTHON_VERSION=3.6 MAIN_CMD='pytest --flake8 changebot' CONDA_DEPENDENCIES="pytest pytest-flake8 requests flask cryptography python-dateutil toml" PIP_DEPENDENCIES="flask-dance pygithub humanize"
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ The main logic is defined in
 If ``CHANGES.rst``, ``CHANGES``, or ``CHANGES.md`` file does not exist in the
 repository, bot will not comment at all.
 
-For repositories that do not use a changelog, this checker can be disabled
-by defining ``changelog_check: false`` in ``.astropybot.yml`` at the top
-level of the repository.
+For repositories that do not use a changelog, this checker can be disabled by
+defining ``changelog_check: false`` in the ``[tool.stsci-bot]`` section of
+``pyproject.toml`` at the top level of the repository.
 
 ### Stale issue and pull request checkers
 
@@ -227,8 +227,8 @@ Heroku:
 
   For repositories that do not want to ever close stale pull requests,
   this feature can be permanently disabled by defining
-  ``autoclose_stale_pull_request: false`` in ``.astropybot.yml`` at the top
-  level of the repository.
+  ``autoclose_stale_pull_request: false`` in the ``[tool.stsci-bot]`` section
+  of ``pyproject.toml`` at the top level of the repository.
 
 * ``STALE_PULL_REQUEST_WARN_SECONDS``, which is the time in seconds from the
   last commit in order to be warned that it will be closed.

--- a/changebot/blueprints/changelog_helpers.py
+++ b/changebot/blueprints/changelog_helpers.py
@@ -49,7 +49,7 @@ def find_prs_in_changelog_by_section(content):
     return changelog_prs
 
 
-def check_changelog_consistency(repo_handler, pr_handler):
+def check_changelog_consistency(repo_handler, pr_handler, check_milestone=True):
 
     for filename in ('CHANGES.rst', 'CHANGES', 'CHANGES.md', 'CHANGELOG.rst'):
         try:
@@ -61,15 +61,18 @@ def check_changelog_consistency(repo_handler, pr_handler):
     else:
         return ["This repository does not appear to have a change log!"]
 
-    return review_changelog(pr_handler.number, changelog,
-                            pr_handler.milestone, pr_handler.labels)
+    milestone = pr_handler.milestone if check_milestone else None
+
+    return review_changelog(pr_handler.number, changelog, milestone,
+                            pr_handler.labels, check_milestone=check_milestone)
 
 
-def review_changelog(pull_request, changelog, milestone, labels):
+def review_changelog(pull_request, changelog, milestone, labels,
+                     check_milestone=True):
 
     issues = []
 
-    if not milestone:
+    if check_milestone and not milestone:
         issues.append("The milestone has not been set (this can only be set by a maintainer)")
 
     sections = find_prs_in_changelog_by_section(changelog)

--- a/changebot/blueprints/pull_request_checker.py
+++ b/changebot/blueprints/pull_request_checker.py
@@ -46,7 +46,7 @@ def hook():
     return process_changelog_consistency(payload['repository']['full_name'], number, installation)
 
 
-CHANGELOG_PROLOGUE = re.sub('(\w+)\n', r'\1', """
+CHANGELOG_PROLOGUE = re.sub(r'(\w+)\n', r'\1', """
 Hi there @{user} :wave: - thanks for the pull request! I'm just
  a friendly :robot: that checks for
  issues related to the changelog. I help make sure that this
@@ -56,24 +56,24 @@ Hi there @{user} :wave: - thanks for the pull request! I'm just
  you know if any action is required on your part :smiley:.
 """).strip() + os.linesep + os.linesep
 
-CHANGELOG_NOT_DONE = re.sub('(\w+)\n', r'\1', """
+CHANGELOG_NOT_DONE = re.sub(r'(\w+)\n', r'\1', """
 I see this is {status} pull request. I'll report back
  on the checks once the PR {is_done}.
 """).strip()
 
-CHANGELOG_BAD_LIST = re.sub('(\w+)\n', r'\1', """
+CHANGELOG_BAD_LIST = re.sub(r'(\w+)\n', r'\1', """
 I noticed the following issues with this pull request:
 """).strip() + os.linesep + os.linesep
 
-CHANGELOG_BAD_EPILOGUE = os.linesep + re.sub('(\w+)\n', r'\1', """
+CHANGELOG_BAD_EPILOGUE = os.linesep + re.sub(r'(\w+)\n', r'\1', """
 Would it be possible to fix these? Thanks!
 """).strip()
 
-CHANGELOG_GOOD = re.sub('(\w+)\n', r'\1', """
+CHANGELOG_GOOD = re.sub(r'(\w+)\n', r'\1', """
 Everything looks good from my point of view! :+1:
 """).strip()
 
-CHANGELOG_EPILOGUE = os.linesep + os.linesep + re.sub('(\w+)\n', r'\1', """
+CHANGELOG_EPILOGUE = os.linesep + os.linesep + re.sub(r'(\w+)\n', r'\1', """
 *If there are any issues with this message, please report them
  [here](https://github.com/spacetelescope/stsci-bot/issues).*
 """).strip()

--- a/changebot/blueprints/pull_request_checker.py
+++ b/changebot/blueprints/pull_request_checker.py
@@ -124,7 +124,9 @@ def process_changelog_consistency(repository, number, installation):
 
     else:
         # Run checks
-        issues = check_changelog_consistency(repo_handler, pr_handler)
+        check_milestone = repo_handler.get_config_value('check_milestone', True)
+        issues = check_changelog_consistency(repo_handler, pr_handler,
+                                             check_milestone=check_milestone)
 
         if len(issues) > 0:
 

--- a/changebot/blueprints/stale_pull_requests.py
+++ b/changebot/blueprints/stale_pull_requests.py
@@ -20,7 +20,7 @@ def close_stale_pull_requests():
     return "All good"
 
 
-PULL_REQUESTS_CLOSE_WARNING = re.sub('(\w+)\n', r'\1', """
+PULL_REQUESTS_CLOSE_WARNING = re.sub(r'(\w+)\n', r'\1', """
 Hi humans :wave: - this pull request hasn't had any new commits for
  approximately {pasttime}. **I plan to close this in {futuretime} if the pull
  request doesn't have any new commits by then.**
@@ -43,7 +43,7 @@ def is_close_warning(message):
     return 'Hi humans :wave: - this pull request hasn\'t had any new commits' in message
 
 
-PULL_REQUESTS_CLOSE_EPILOGUE = re.sub('(\w+)\n', r'\1', """
+PULL_REQUESTS_CLOSE_EPILOGUE = re.sub(r'(\w+)\n', r'\1', """
 :alarm_clock: Time's up! :alarm_clock:
 
 I'm going to close this pull request as per my previous message. If you

--- a/changebot/github/github_api.py
+++ b/changebot/github/github_api.py
@@ -5,8 +5,8 @@ import requests
 import time
 import warnings
 
+import toml
 import dateutil.parser
-import yaml
 
 from changebot.github.github_auth import github_request_headers
 
@@ -107,7 +107,7 @@ class RepoHandler(object):
         contents_base64 = response.json()['content']
         return base64.b64decode(contents_base64).decode()
 
-    def get_user_config(self, path_to_file='.astropybot.yml',
+    def get_user_config(self, path_to_file='pyproject.toml', name='stsci-bot',
                         warn_on_failure=True):
         """
         Load user configuration for bot.
@@ -115,11 +115,11 @@ class RepoHandler(object):
         Parameters
         ----------
         path_to_file : str
-            Configuration file in YAML format in the repository.
+            Configuration file in TOML format in the repository.
             If not given or invalid, default is used.
 
         warn_on_failure : bool
-            Emit warning on failure to load YAML file.
+            Emit warning on failure to load TOML file.
 
         Returns
         -------
@@ -136,7 +136,9 @@ class RepoHandler(object):
             # Empty dict means calling code set the default
             cfg = {}
         else:
-            cfg = yaml.load(file_content)
+            content = toml.loads(file_content)
+            section = content.get('tool', {})
+            cfg = section.get(name, {})
 
         return cfg
 

--- a/changebot/github/tests/test_github_api.py
+++ b/changebot/github/tests/test_github_api.py
@@ -1,4 +1,3 @@
-import warnings
 from unittest.mock import patch, Mock, PropertyMock
 
 import pytest
@@ -42,8 +41,8 @@ autoclose_stale_pull_request = false
     """
     repo = RepoHandler('fake/fakebot')
 
-    assert repo.get_config_value('changelog_check', True) == False
-    assert repo.get_config_value('autoclose_stale_pull_request', True) == False
+    assert repo.get_config_value('changelog_check', True) is False
+    assert repo.get_config_value('autoclose_stale_pull_request', True) is False
     assert repo.get_config_value('bizbaz', 42) == 42
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ requests
 cryptography
 python-dateutil
 humanize
-pyyaml
+toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
 [flake8]
 # E501: line too long
-ignore = E501
-
-[tool:pytest]
-flake8-ignore = E501
+ignore = E501,W503,W504


### PR DESCRIPTION
With this change, the `[tool.stsci-bot]` section of the `pyproject.toml` file should be used for configuring the bot. This PR also adds a new configuration variable `check_milestone` which can be set to `false` in order to disable the milestone check.